### PR TITLE
Update NetHelper.swift

### DIFF
--- a/Net/NetHelper.swift
+++ b/Net/NetHelper.swift
@@ -94,7 +94,7 @@ class NetHelper
                 let netData = value as NetData
                 valueData = netData.data
                 valueType = netData.mimeType.getString()
-                filenameClause = " \"filename=\"\(netData.filename)\""
+                filenameClause = " filename=\"\(netData.filename)\""
             }
             else {
                 let stringValue = "\(value)"


### PR DESCRIPTION
There is a extra quote before filename tag, and it will cause the failure of some multipartform parser.
