### PR TITLE
Allow custom headers to be set

### DIFF
--- a/Net/Net.swift
+++ b/Net/Net.swift
@@ -49,14 +49,18 @@ class Net : NSObject, NSURLSessionDataDelegate, NSURLSessionDownloadDelegate, NS
     // upload tasks dictionary
     private var uploaders = [NSURLSessionUploadTask: UploadTask]()
     
-    init(baseUrlString: String) {
+    init(baseUrlString: String, var headers: Dictionary<String, String>) {
         baseUrl = NSURL(string: baseUrlString)
         requestSerializer = RequestSerialization()
         
         // config defaul session
         sessionConfig = NSURLSessionConfiguration.defaultSessionConfiguration()
         sessionConfig.allowsCellularAccess = true
-        sessionConfig.HTTPAdditionalHeaders = ["Accept": "application/json,application/xml,image/png,image/jpeg"]
+        
+        // set custom headers
+        headers.updateValue("application/json,application/xml,image/png,image/jpeg", forKey: "Accept")
+        sessionConfig.HTTPAdditionalHeaders = headers
+        
         sessionConfig.timeoutIntervalForRequest = 30.0
         sessionConfig.timeoutIntervalForResource = 60.0
         sessionConfig.HTTPMaximumConnectionsPerHost = HTTPMaximumconnectionsPerHost
@@ -64,8 +68,14 @@ class Net : NSObject, NSURLSessionDataDelegate, NSURLSessionDownloadDelegate, NS
         session = NSURLSession(configuration: sessionConfig)
     }
     
+    convenience init(baseUrlString: String) {
+        var headers = [String: String]()
+        self.init(baseUrlString: baseUrlString, headers: headers)
+    }
+
     convenience override init() {
-        self.init(baseUrlString: "")
+        var headers = [String: String]()
+        self.init(baseUrlString: "", headers: headers)
     }
     
     func setupSession(backgroundIdentifier: String? = nil) {

--- a/Net/NetResponseData.swift
+++ b/Net/NetResponseData.swift
@@ -13,12 +13,12 @@ class ResponseData
 {
     var urlResponse : NSURLResponse
     var data: NSData
-    
+
     init(response: NSURLResponse, data: NSData) {
         self.urlResponse = response
         self.data = data
     }
-   
+
     /**
     *  parse json with urlResponse
     *
@@ -35,10 +35,10 @@ class ResponseData
         else if error != nil {
             error.memory = NSError(domain: "HTTP_ERROR_CODE", code: httpResponse.statusCode, userInfo: nil)
         }
-        
+
         return nil
     }
-    
+
     /**
     *  convert urlResponse to image
     *
@@ -52,16 +52,16 @@ class ResponseData
         else if error != nil {
             error.memory = NSError(domain: "HTTP_ERROR_CODE", code: httpResponse.statusCode, userInfo: nil)
         }
-        
+
         return nil
     }
-    
+
     /**
     *  parse xml
     *
     *  @param NSXMLParserDelegate
     *
-    *  @return 
+    *  @return
     */
     func parseXml(delegate: NSXMLParserDelegate, error: NSErrorPointer = nil) -> Bool {
         let httpResponse = urlResponse as NSHTTPURLResponse
@@ -74,7 +74,7 @@ class ResponseData
         else if error != nil {
             error.memory = NSError(domain: "HTTP_ERROR_CODE", code: httpResponse.statusCode, userInfo: nil)
         }
-        
+
         return false
     }
 }


### PR DESCRIPTION
This allows custom headers to be set on when a Net object is initialized.

Example usage: https://gist.github.com/JonathanPorta/e1adc7962504d3f965a6
