### PR TITLE
Update for Xcode 6.1

### DIFF
--- a/Net/Net.swift
+++ b/Net/Net.swift
@@ -49,10 +49,10 @@ class Net : NSObject, NSURLSessionDataDelegate, NSURLSessionDownloadDelegate, NS
     // upload tasks dictionary
     private var uploaders = [NSURLSessionUploadTask: UploadTask]()
     
-    init(baseUrlString: String, var headers: Dictionary<String, String>) {
-        baseUrl = NSURL(string: baseUrlString)
+    init(var baseUrlString: String, var headers: Dictionary<String, String>) {
+        baseUrl = NSURL(string: baseUrlString)!
         requestSerializer = RequestSerialization()
-        
+
         // config defaul session
         sessionConfig = NSURLSessionConfiguration.defaultSessionConfiguration()
         sessionConfig.allowsCellularAccess = true
@@ -302,10 +302,10 @@ class Net : NSObject, NSURLSessionDataDelegate, NSURLSessionDownloadDelegate, NS
     *  @return request instance
     */
     private func httpRequest(method: HttpMethod, url: String, params: NSDictionary?, successHandler: SuccessHandler, failureHandler: FailureHandler, isAbsoluteUrl: Bool = false) -> NSURLSessionTask {
-        let urlString = isAbsoluteUrl ? url : NSURL(string: url, relativeToURL: baseUrl).absoluteString
-        NSLog(urlString!)
+        let urlString = isAbsoluteUrl ? url : "\(baseUrl.absoluteString!)\(url)"
+        NSLog(urlString)
         
-        let request = requestSerializer.requestWithMethod(method, urlString: urlString!, params: params, error: nil)
+        let request = requestSerializer.requestWithMethod(method, urlString: urlString, params: params, error: nil)
         let task = createSessionTaskWithRequest(request, successHandler: successHandler, failureHandler: failureHandler)
         task.resume()
         

--- a/Net/NetData.swift
+++ b/Net/NetData.swift
@@ -25,7 +25,7 @@ enum MimeType: String {
         case .ImageGif:
             fallthrough
         case .Json:
-            return self.toRaw()
+            return self.rawValue
         case .Unknown:
             fallthrough
         default:

--- a/Net/NetDownloadTask.swift
+++ b/Net/NetDownloadTask.swift
@@ -40,9 +40,9 @@ class DownloadTask
         
         // create task
         let url = NSURL(string: absoluteUrl)
-        request = NSMutableURLRequest(URL: url)
+        request = NSMutableURLRequest(URL: url!)
         // TODO: config for request
-        request.HTTPMethod = HttpMethod.GET.toRaw()
+        request.HTTPMethod = HttpMethod.GET.rawValue
         task = session.downloadTaskWithRequest(request)
         
         self.progressHandler = progressHandler

--- a/Net/NetRequestSerialization.swift
+++ b/Net/NetRequestSerialization.swift
@@ -26,8 +26,8 @@ class RequestSerialization
     */
     func requestWithMethod(method: HttpMethod, urlString: String, params: NSDictionary?, error: NSErrorPointer?) -> (NSMutableURLRequest) {
         let url = NSURL(string: urlString)
-        let request = NSMutableURLRequest(URL: url)
-        request.HTTPMethod = method.toRaw()
+        let request = NSMutableURLRequest(URL: url!)
+        request.HTTPMethod = method.rawValue
         request.HTTPShouldUsePipelining = HTTPShouldUsePipelining
         request.HTTPShouldHandleCookies = HTTPSouhdHandleCookies
         request.allowsCellularAccess = allowsCellularAccess

--- a/Net/NetUploadTask.swift
+++ b/Net/NetUploadTask.swift
@@ -36,8 +36,8 @@ class UploadTask
         self.session = session
         self.delegate = delegate
         let url = NSURL(string: absoluteUrl)
-        self.request = NSMutableURLRequest(URL: url)
-        request.HTTPMethod = HttpMethod.POST.toRaw()
+        self.request = NSMutableURLRequest(URL: url!)
+        request.HTTPMethod = HttpMethod.POST.rawValue
     
         self.progressHandler = progressHandler
         self.completionHandler = completionHandler
@@ -78,7 +78,7 @@ class UploadTask
     }
     
     func setHttpMethod(method: HttpMethod) {
-        request.HTTPMethod = method.toRaw()
+        request.HTTPMethod = method.rawValue
     }
     
     func setValue(value: String, forHttpHeaderField field: String) {


### PR DESCRIPTION
- Utilize `rawValue` instead of `toRaw()` due to method being removed.
- Fixes various compiler warnings surfacing in Xcode 6.1.

More information in the Xcode 6.1 [release notes])(https://developer.apple.com/library/ios/releasenotes/DeveloperTools/RN-Xcode/Chapters/xc6_release_notes.html#//apple_ref/doc/uid/TP40001051-CH4-DontLinkElementID_23).
